### PR TITLE
update and align plugin name

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# release.sh — build a release candidate zip for MinecraftTS
+# release.sh — build a release candidate zip for TS3Bridge
 #
-# Output: release/MinecraftTS-<version>.zip
-#   ├── MinecraftTS-<version>.jar   (fat jar — drop into plugins/)
+# Output: release/TS3Bridge-<version>.zip
+#   ├── TS3Bridge-<version>.jar   (fat jar — drop into plugins/)
 #   ├── README.md
 #   └── CHANGELOG.md
 # ---------------------------------------------------------------------------
@@ -20,11 +20,11 @@ set +u; source "$HOME/.sdkman/bin/sdkman-init.sh" 2>/dev/null || true; set -u
 
 # --- Determine version from the built jar ---
 JAR=$(ls build/libs/*.jar | head -1)
-FILENAME=$(basename "$JAR")                        # minecraft-ts3-plugin-1.0.0-SNAPSHOT.jar
-VERSION="${FILENAME#minecraft-ts3-plugin-}"        # 1.0.0-SNAPSHOT.jar
-VERSION="${VERSION%.jar}"                          # 1.0.0-SNAPSHOT
+FILENAME=$(basename "$JAR")                   # ts3-bridge-1.0.0-SNAPSHOT.jar
+VERSION="${FILENAME#ts3-bridge-}"             # 1.0.0-SNAPSHOT.jar
+VERSION="${VERSION%.jar}"                     # 1.0.0-SNAPSHOT
 
-RELEASE_NAME="MinecraftTS-${VERSION}"
+RELEASE_NAME="TS3Bridge-${VERSION}"
 RELEASE_DIR="release/${RELEASE_NAME}"
 ZIP_PATH="release/${RELEASE_NAME}.zip"
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ out/
 .LSOverride
 
 # Plugin runtime files (never commit live server credentials or player data)
-plugins/MinecraftTS/config.json
-plugins/MinecraftTS/mappings.json
+plugins/TS3Bridge/config.json
+plugins/TS3Bridge/mappings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to MinecraftTS are documented here.
+All notable changes to TS3Bridge are documented here.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
@@ -155,7 +155,7 @@ The `advertisementMode` config field and `ACTIONBAR` delivery path have been rem
 
 ### Iteration 13 — Configurable ServerQuery nickname
 
-- **Added** `tsQueryNickname` to `PluginConfig` (default `"MinecraftTS"`)
+- **Added** `tsQueryNickname` to `PluginConfig` (default `"TS3Bridge"`)
 - `TeamspeakConnection.connect()` now calls `api.setNickname()` after selecting the virtual server, so MC→TS chat messages appear under a recognisable name instead of the query account name
 - Fixes the "Spy981"-style display where the query account name collided with a real player's TS nickname (causing TS to append a number)
 
@@ -252,7 +252,7 @@ The `advertisementMode` config field and `ACTIONBAR` delivery path have been rem
 | `tsServerAddress` | `localhost` | Address advertised to players |
 | `advertisementMessage` | `Join our TeamSpeak server: {address}` | Join message template (see iteration 12) |
 | `chatBridgeEnabled` | `true` | Enable/disable MC↔TS chat relay |
-| `tsQueryNickname` | `MinecraftTS` | Nickname shown in TS for ServerQuery messages (see iteration 13) |
+| `tsQueryNickname` | `TS3Bridge` | Nickname shown in TS for ServerQuery messages (see iteration 13) |
 | `tsBridgeChannelId` | `0` | TS channel ID for the chat bridge; 0 = server-wide (see iteration 14) |
 | `debugLogging` | `false` | Log raw TS event data at INFO for bridge diagnostics (see iteration 22) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# minecraft-ts3-plugin — CLAUDE.md
+# TS3Bridge — CLAUDE.md
 
 A Minecraft plugin bridging Minecraft chat and player presence with a TeamSpeak 3 server via ServerQuery.
 
@@ -45,7 +45,7 @@ Base: `de.thomasuebel.mc.ts3bridge`
 | `tsVirtualServerId` | `1` | Virtual server ID |
 | `tsVirtualServerPort` | `0` | Voice port (when > 0, overrides `tsVirtualServerId`) |
 | `tsServerAddress` | `localhost` | Address shown in advertisement |
-| `tsQueryNickname` | `MinecraftTS` | Bot display name in TS |
+| `tsQueryNickname` | `TS3Bridge` | Bot display name in TS |
 | `tsBridgeChannelId` | `0` | Bridge channel ID; 0 = server-wide |
 | `advertisementMessage` | `Join our TeamSpeak server: {address}` | Join message template |
 | `chatBridgeEnabled` | `true` | Enable MC↔TS chat relay |
@@ -71,7 +71,7 @@ LuckPerms nodes; vanilla OP as fallback. Admin commands (`status`, `reload`, `li
 
 ## Plugin Metadata
 
-- **Name:** `MinecraftTS`
+- **Name:** `TS3Bridge`
 - **Main class:** `de.thomasuebel.mc.ts3bridge.minecraft.MctsPlugin`
 - **API version:** `1.21`
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# MinecraftTS
+# TS3Bridge
 
 My kids play Minecraft and wanted to talk to each other while doing so. I prefer TeamSpeak to Discord - self-hosted, no big tech, no accounts required for voice. The existing plugins (TeamspeakIP, BukkitSpeak) didn't work with the virtual server setup I have through 4netplayers hosting, so I built this one. Hope someone finds it useful.
 
 ---
 
-MinecraftTS is a [Paper](https://papermc.io/) plugin that bridges Minecraft and a TeamSpeak 3 server via ServerQuery:
+TS3Bridge is a [Paper](https://papermc.io/) plugin for Minecraft that creates a bridge between Minecraft and a TeamSpeak 3 server via ServerQuery:
 
 - Bidirectional chat relay between MC and TS
 - Join/leave announcements in both directions
@@ -24,14 +24,14 @@ MinecraftTS is a [Paper](https://papermc.io/) plugin that bridges Minecraft and 
 ## Installation
 
 1. Drop the JAR into `plugins/`.
-2. Start the server -  `plugins/MinecraftTS/config.json` is created with defaults.
+2. Start the server -  `plugins/TS3Bridge/config.json` is created with defaults.
 3. Stop, fill in your TS credentials, restart (or `/ts reload`).
 
 ---
 
 ## Configuration
 
-`plugins/MinecraftTS/config.json`:
+`plugins/TS3Bridge/config.json`:
 
 ```json
 {
@@ -41,7 +41,7 @@ MinecraftTS is a [Paper](https://papermc.io/) plugin that bridges Minecraft and 
   "tsQueryPassword": "your-query-password",
   "tsVirtualServerId": 1,
   "tsVirtualServerPort": 0,
-  "tsQueryNickname": "MinecraftTS",
+  "tsQueryNickname": "TS3Bridge",
   "tsBridgeChannelId": 0,
   "tsServerAddress": "your-ts3-host.example.com",
   "advertisementMessage": "Join our TeamSpeak server: {address}",
@@ -58,7 +58,7 @@ MinecraftTS is a [Paper](https://papermc.io/) plugin that bridges Minecraft and 
 | `tsQueryPassword` | *(empty)* | ServerQuery password |
 | `tsVirtualServerId` | `1` | Virtual server ID -  ignored when `tsVirtualServerPort > 0` |
 | `tsVirtualServerPort` | `0` | Voice port -  use this for hosted providers instead of the ID (see below) |
-| `tsQueryNickname` | `MinecraftTS` | Bot name shown in TS |
+| `tsQueryNickname` | `TS3Bridge` | Bot name shown in TS |
 | `tsBridgeChannelId` | `0` | Restrict bridge to a specific channel; `0` = server-wide |
 | `tsServerAddress` | `localhost` | Address shown in the join advertisement |
 | `advertisementMessage` | `Join our TeamSpeak server: {address}` | Sent to unlinked players on join |
@@ -120,7 +120,7 @@ Set `tsBridgeChannelId` to a channel ID to scope everything to one channel. The 
 ./gradlew shadowJar
 ```
 
-Output: `build/libs/minecraft-ts3-plugin-<version>.jar`
+Output: `build/libs/ts3-bridge-<version>.jar`
 
 ---
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'minecraft-ts3-plugin'
+rootProject.name = 'ts3-bridge'

--- a/src/main/java/de/thomasuebel/mc/ts3bridge/configuration/PluginConfig.java
+++ b/src/main/java/de/thomasuebel/mc/ts3bridge/configuration/PluginConfig.java
@@ -15,7 +15,7 @@ public class PluginConfig {
     // Message sent to players on join. Use {address} as a placeholder for tsServerAddress.
     private String advertisementMessage = "Join our TeamSpeak server: {address}";
     private boolean chatBridgeEnabled = true;
-    private String tsQueryNickname = "MinecraftTS";
+    private String tsQueryNickname = "TS3Bridge";
     // Channel ID for the chat bridge. 0 = no channel filter (server-wide messages).
     private int tsBridgeChannelId = 0;
     // When true, raw TS event map contents are logged at INFO for debugging.

--- a/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/MctsPlugin.java
+++ b/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/MctsPlugin.java
@@ -32,7 +32,7 @@ public class MctsPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        getLogger().info("Shutting down MinecraftTS...");
+        getLogger().info("Shutting down TS3Bridge...");
 
         if (mappingsRepository != null) {
             getLogger().info("Saving player mappings...");
@@ -42,11 +42,11 @@ public class MctsPlugin extends JavaPlugin {
             teamspeakConnection.disconnect();
         }
 
-        getLogger().info("MinecraftTS disabled.");
+        getLogger().info("TS3Bridge disabled.");
     }
 
     public void reload() {
-        getLogger().info("Reloading MinecraftTS...");
+        getLogger().info("Reloading TS3Bridge...");
 
         if (mappingsRepository != null) {
             getLogger().info("Saving player mappings...");
@@ -60,7 +60,7 @@ public class MctsPlugin extends JavaPlugin {
 
         initialize();
 
-        getLogger().info("MinecraftTS reload complete.");
+        getLogger().info("TS3Bridge reload complete.");
     }
 
     private void initialize() {
@@ -140,7 +140,7 @@ public class MctsPlugin extends JavaPlugin {
         // --- TS→MC chat bridge ---
         registerTsToMcBridge(chatBridgeService, config.isDebugLogging());
 
-        getLogger().info("MinecraftTS enabled successfully.");
+        getLogger().info("TS3Bridge enabled successfully.");
     }
 
     /**

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: MinecraftTS
+name: TS3Bridge
 version: '${version}'
 main: de.thomasuebel.mc.ts3bridge.minecraft.MctsPlugin
 api-version: '1.21'

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/configuration/ConfigManagerTest.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/configuration/ConfigManagerTest.java
@@ -48,7 +48,7 @@ class ConfigManagerTest {
         assertEquals(10011, config.getTsQueryPort());
         assertEquals(1, config.getTsVirtualServerId());
         assertTrue(config.isChatBridgeEnabled());
-        assertEquals("MinecraftTS", config.getTsQueryNickname());
+        assertEquals("TS3Bridge", config.getTsQueryNickname());
         assertEquals(0, config.getTsBridgeChannelId());
     }
 

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/command/TsCommandTest.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/command/TsCommandTest.java
@@ -112,7 +112,7 @@ class TsCommandTest {
 
         verify(sender).sendMessage("[TS] Status: Connected");
         verify(sender).sendMessage(contains("localhost:10011"));
-        verify(sender).sendMessage(contains("MinecraftTS"));
+        verify(sender).sendMessage(contains("TS3Bridge"));
         verify(sender).sendMessage(contains("server-wide"));
         verify(sender).sendMessage(contains("enabled"));
         verify(sender).sendMessage(contains("Clients online: 2"));


### PR DESCRIPTION
In preparation for a release on modrinth, the plugin name is changed so it doesn't contain Minecraft or TeamSpeak and makes this project a target of greedy copyright sharks.