### PR TITLE
Fix stale plugin.yml version in incremental builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 }
 
 processResources {
+    inputs.property('version', project.version)
     filesMatching('plugin.yml') {
         expand(version: project.version)
     }


### PR DESCRIPTION
## Summary

- Server reported the old version on load (e.g. `TS3Bridge (1.0.1-SNAPSHOT)`) after a version bump
- Root cause: Gradle's UP-TO-DATE check for `processResources` only tracked source file changes — the `project.version` property used in `expand()` was not registered as a task input, so incremental builds skipped re-processing `plugin.yml`
- Fix: add `inputs.property('version', project.version)` so Gradle invalidates the task output whenever the version changes

## Test plan

- [ ] `./gradlew clean shadowJar` — `plugin.yml` in jar shows correct version
- [ ] Bump version in `build.gradle`, run `./gradlew shadowJar` (no clean) — `processResources` re-runs, jar shows new version
- [ ] No clean required to get a correct build after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)