### PR TITLE
fix: advertise to unlinked players on every join (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Bug Fixes
+- Unlinked players now receive the TeamSpeak advertisement on **every** join, not only the first one per plugin lifecycle (#11). Previously, an in-memory session cache suppressed subsequent rejoins and the log misreported the reason as `(account is linked)`.
+
+### Changed
+- `AdvertisementService` simplified: removed the `advertisedThisSession` set and `markAdvertised(UUID)` method. `shouldAdvertise(UUID)` now returns `!repository.isLinked(uuid)`.
+
+---
+
 ## 1.1.6
 
 ### Added

--- a/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementService.java
+++ b/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementService.java
@@ -3,15 +3,12 @@ package de.thomasuebel.mc.ts3bridge.minecraft;
 import de.thomasuebel.mc.ts3bridge.configuration.PluginConfig;
 import de.thomasuebel.mc.ts3bridge.user.MappingsRepository;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 
 public class AdvertisementService {
 
     private final PluginConfig config;
     private final MappingsRepository repository;
-    private final Set<UUID> advertisedThisSession = new HashSet<>();
 
     public AdvertisementService(PluginConfig config, MappingsRepository repository) {
         this.config = config;
@@ -21,16 +18,9 @@ public class AdvertisementService {
     /**
      * Returns true if the player should receive the TS advertisement on join.
      * Linked players are skipped — they already know about TeamSpeak.
-     * Players who have already been advertised this session are skipped.
      */
     public boolean shouldAdvertise(UUID playerUuid) {
-        if (repository.isLinked(playerUuid)) return false;
-        if (advertisedThisSession.contains(playerUuid)) return false;
-        return true;
-    }
-
-    public void markAdvertised(UUID playerUuid) {
-        advertisedThisSession.add(playerUuid);
+        return !repository.isLinked(playerUuid);
     }
 
     public String buildAdvertisementMessage() {

--- a/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/listener/PlayerJoinListener.java
+++ b/src/main/java/de/thomasuebel/mc/ts3bridge/minecraft/listener/PlayerJoinListener.java
@@ -40,7 +40,6 @@ public class PlayerJoinListener implements Listener {
         }
 
         player.sendMessage(Component.text(advertisementService.buildAdvertisementMessage()));
-        advertisementService.markAdvertised(player.getUniqueId());
         logger.info("Sent TeamSpeak advertisement to player '" + player.getName() + "'.");
     }
 }

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
@@ -81,4 +81,18 @@ class AdvertisementServiceTest {
         AdvertisementService freshService = new AdvertisementService(config, repository);
         assertTrue(freshService.shouldAdvertise(uuid));
     }
+
+    // Issue #11: documents the CURRENT (buggy) behavior — an unlinked player who
+    // rejoins in the same plugin lifecycle is suppressed by the in-memory session
+    // cache. The next commit flips this assertion to the desired behavior.
+    @Test
+    void bug_unlinkedPlayerIsSuppressedOnRejoinInSameSession() {
+        UUID uuid = UUID.randomUUID();
+
+        assertTrue(service.shouldAdvertise(uuid), "first join: unlinked player should get the ad");
+        service.markAdvertised(uuid);
+
+        assertFalse(service.shouldAdvertise(uuid),
+                "rejoin: BUG — ad is suppressed even though the player is not linked");
+    }
 }

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
@@ -61,27 +61,6 @@ class AdvertisementServiceTest {
         assertFalse(service.shouldAdvertise(uuid));
     }
 
-    @Test
-    void advertisementIsShownOnFirstVisit() {
-        UUID uuid = UUID.randomUUID();
-        assertTrue(service.shouldAdvertise(uuid));
-    }
-
-    @Test
-    void advertisementIsSuppressedAfterMarkAdvertised() {
-        UUID uuid = UUID.randomUUID();
-        service.markAdvertised(uuid);
-        assertFalse(service.shouldAdvertise(uuid));
-    }
-
-    @Test
-    void advertisementIsShownAgainAfterServiceReinit() {
-        UUID uuid = UUID.randomUUID();
-        service.markAdvertised(uuid);
-        AdvertisementService freshService = new AdvertisementService(config, repository);
-        assertTrue(freshService.shouldAdvertise(uuid));
-    }
-
     // Issue #11: an unlinked player must see the advertisement on every join,
     // not just the first one within a plugin lifecycle.
     @Test
@@ -89,9 +68,6 @@ class AdvertisementServiceTest {
         UUID uuid = UUID.randomUUID();
 
         assertTrue(service.shouldAdvertise(uuid), "first join: unlinked player should get the ad");
-        service.markAdvertised(uuid);
-
-        assertTrue(service.shouldAdvertise(uuid),
-                "rejoin: unlinked player should still get the ad");
+        assertTrue(service.shouldAdvertise(uuid), "rejoin: unlinked player should still get the ad");
     }
 }

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/AdvertisementServiceTest.java
@@ -82,17 +82,16 @@ class AdvertisementServiceTest {
         assertTrue(freshService.shouldAdvertise(uuid));
     }
 
-    // Issue #11: documents the CURRENT (buggy) behavior — an unlinked player who
-    // rejoins in the same plugin lifecycle is suppressed by the in-memory session
-    // cache. The next commit flips this assertion to the desired behavior.
+    // Issue #11: an unlinked player must see the advertisement on every join,
+    // not just the first one within a plugin lifecycle.
     @Test
-    void bug_unlinkedPlayerIsSuppressedOnRejoinInSameSession() {
+    void unlinkedPlayerSeesAdvertisementOnEveryJoin() {
         UUID uuid = UUID.randomUUID();
 
         assertTrue(service.shouldAdvertise(uuid), "first join: unlinked player should get the ad");
         service.markAdvertised(uuid);
 
-        assertFalse(service.shouldAdvertise(uuid),
-                "rejoin: BUG — ad is suppressed even though the player is not linked");
+        assertTrue(service.shouldAdvertise(uuid),
+                "rejoin: unlinked player should still get the ad");
     }
 }

--- a/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/FakeAdvertisementService.java
+++ b/src/test/java/de/thomasuebel/mc/ts3bridge/minecraft/FakeAdvertisementService.java
@@ -27,9 +27,4 @@ public class FakeAdvertisementService extends AdvertisementService {
     public String buildAdvertisementMessage() {
         return "Join our TeamSpeak server: ts.example.com";
     }
-
-    @Override
-    public void markAdvertised(UUID playerUuid) {
-        // no-op in test double
-    }
 }


### PR DESCRIPTION
Closes #11

## Summary
- Drops the in-memory `advertisedThisSession` cache in `AdvertisementService`. Unlinked players now receive the TS advertisement on **every** join, not just the first one per plugin lifecycle.
- Fixes the secondary symptom where `PlayerJoinListener` mislabelled the suppression as `(account is linked)` whenever the real cause was the session cache.
- Simplifies the API: `markAdvertised()` removed; `shouldAdvertise(uuid)` is now `!repository.isLinked(uuid)`.

## Commit trail (TDD)
1. `test: document advertisement-skip bug for unlinked rejoin` — pins the current buggy behavior so the regression is captured first.
2. `test: assert desired behavior — unlinked player sees ad on every join` — flips the assertion; red against current code.
3. `fix: advertise to unlinked players on every join` — implementation + obsolete-test cleanup + `CHANGELOG.md [Unreleased]`.

## Test plan
- [x] `./gradlew test` — full suite green on fix branch
- [ ] Manual: start a Paper 1.21.1 server, empty `mappings.json`, have a player join → leave → rejoin → confirm the ad fires both times and no `(account is linked)` log appears
- [ ] Manual: link a player via `/ts link`, have them join → confirm ad is correctly skipped with the `(account is linked)` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)